### PR TITLE
Expose nats streaming sequence number as a transport property

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -79,6 +79,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.siddhi.extension.map.text</groupId>
+            <artifactId>siddhi-map-text</artifactId>
+            <version>2.0.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -79,11 +79,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.siddhi.extension.map.text</groupId>
-            <artifactId>siddhi-map-text</artifactId>
-            <version>2.0.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -74,6 +74,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.siddhi.extension.execution.math</groupId>
+            <artifactId>siddhi-execution-math</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/component/src/main/java/io/siddhi/extension/io/nats/source/NATSSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/source/NATSSource.java
@@ -131,7 +131,16 @@ import java.util.concurrent.atomic.AtomicInteger;
                         syntax = "@source(type='nats', @map(type='text'), "
                                 + "destination='SP_NATS_INPUT_TEST', "
                                 + ")\n"
-                                + "define stream inputStream (name string, age int, country string);")
+                                + "define stream inputStream (name string, age int, country string);"),
+                @Example(description = "This example shows how to pass NATS Streaming sequence number to the event.",
+                        syntax = "@source(type='nats', @map(type='json', @attributes(name='$.name', age='$.age', " +
+                                "country='$.country', sequenceNum='trp:sequenceNumber')), " +
+                                "destination='SIDDHI_NATS_SOURCE_TEST_DEST', " +
+                                "client.id='nats_client', " +
+                                "bootstrap.servers='nats://localhost:4222', " +
+                                "cluster.id='test-cluster'" +
+                                ")\n" +
+                                "define stream inputStream (name string, age int, country string, sequenceNum string);")
         }
 )
 

--- a/component/src/main/java/io/siddhi/extension/io/nats/source/NATSSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/source/NATSSource.java
@@ -150,8 +150,7 @@ public class NATSSource extends Source<NATSSource.NATSSourceState> {
     private Subscription subscription;
     private NATSMessageProcessor natsMessageProcessor;
     private String siddhiAppName;
-
-
+    private String[] reqTransportPropertyNames;
 
     @Override
     public StateFactory<NATSSourceState> init(SourceEventListener sourceEventListener, OptionHolder optionHolder,
@@ -160,6 +159,7 @@ public class NATSSource extends Source<NATSSource.NATSSourceState> {
         this.sourceEventListener = sourceEventListener;
         this.optionHolder = optionHolder;
         this.siddhiAppName = siddhiAppContext.getName();
+        this.reqTransportPropertyNames = requestedTransportPropertyNames.clone();
         initNATSProperties();
         return NATSSourceState::new;
     }
@@ -244,7 +244,8 @@ public class NATSSource extends Source<NATSSource.NATSSourceState> {
             if (durableName != null) {
                 subscriptionOptionsBuilder.durableName(durableName);
             }
-            natsMessageProcessor = new NATSMessageProcessor(sourceEventListener, natsSourceState.lastSentSequenceNo);
+            natsMessageProcessor = new NATSMessageProcessor(sourceEventListener, reqTransportPropertyNames,
+                    natsSourceState.lastSentSequenceNo);
             if (queueGroupName != null) {
                 subscription =  streamingConnection.subscribe(destination , queueGroupName, natsMessageProcessor,
                         subscriptionOptionsBuilder.build());

--- a/component/src/main/java/io/siddhi/extension/io/nats/util/NATSConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/util/NATSConstants.java
@@ -30,4 +30,5 @@ public class NATSConstants {
     public static final String QUEUE_GROUP_NAME = "queue.group.name";
     public static final String DURABLE_NAME = "durable.name";
     public static final String SUBSCRIPTION_SEQUENCE = "subscription.sequence";
+    public static final String SEQUENCE_NUMBER  = "sequenceNumber";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>io.siddhi.extension.execution.math</groupId>
+                <artifactId>siddhi-execution-math</artifactId>
+                <version>${siddhi.execution.math.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven.surefire</groupId>
                 <artifactId>surefire-booter</artifactId>
                 <version>${surefire.booter.version}</version>
@@ -177,6 +183,7 @@
         <org.testcontainers.version>1.8.0</org.testcontainers.version>
         <siddhi.map.protobuf.version>1.0.2</siddhi.map.protobuf.version>
         <com.google.protobuf.java.version>3.9.1</com.google.protobuf.java.version>
+        <siddhi.execution.math.version>5.0.4</siddhi.execution.math.version>
         <argLine>-Xmx1024m</argLine>
     </properties>
 


### PR DESCRIPTION
## Purpose
> Fixes #25 

## Approach
> Expose nats streaming sequence number as a transport property

## Sample
```
@source(type='nats', 
destination='SIDDHI_NATS_SOURCE_TEST_DEST', 
client.id='nats_client', 
bootstrap.servers='nats://localhost:4222', 
cluster.id='test-cluster, 
@map(type='json', @attributes(name='$.name', age='$.age', country='$.country', sequenceNum='trp:sequenceNumber')))
define stream inputStream (name string, age int, country string, sequenceNum string);
```