### PR TITLE
Enable resolution optional for com.google.protobuf dependency

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -239,7 +239,7 @@
                         </Export-Package>
                         <Import-Package>
                             io.nats.client;version="0.0.0";resolution:=optional,
-                            com.google.protobuf.*;version="0.0.0",
+                            com.google.protobuf.*;version="0.0.0";resolution:=optional,
                             io.nats.streaming;version="0.0.0";resolution:=optional,
                             io.siddhi.annotation.*;version="${siddhi.version.range}",
                             io.siddhi.core.*;version="${siddhi.version.range}",


### PR DESCRIPTION
## Purpose
$subject

## Goals
Previously, com.google.protobuf dependency resolved from siddhi-io-grpc. Now siddhi-io-grpc does not export com.google.protobuf. So, we need to make this resolution optional.

## Related PRs
https://github.com/siddhi-io/siddhi-io-grpc/pull/28

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)
libprotoc 3.10.0
nats-streaming-server version 0.16.2, nats-server: v2.0.4
