### PR TITLE
Fix seeking from next seq number during restoring

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/nats/source/NATSSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/source/NATSSource.java
@@ -247,7 +247,7 @@ public class NATSSource extends Source<NATSSource.NATSSourceState> {
                 Integer.parseInt(sequenceNumber)) {
             natsSourceState.lastSentSequenceNo.set(Integer.parseInt(sequenceNumber));
         }
-        subscriptionOptionsBuilder.startAtSequence(natsSourceState.lastSentSequenceNo.get());
+        subscriptionOptionsBuilder.startAtSequence(natsSourceState.lastSentSequenceNo.get() + 1);
         try {
 
             if (durableName != null) {


### PR DESCRIPTION
## Purpose
> With the current implementation, during persisting and restoring, an event get duplicated. Hence, we need to seek from the incremented last sequence number.
