### PR TITLE
Introduce a new parameter(ack.wait)

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/nats/sink/NATSSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/sink/NATSSink.java
@@ -85,6 +85,10 @@ import java.util.Map;
                                 "streaming broker",
                         type = DataType.STRING
                 ),
+                @Parameter(name = NATSConstants.ACK_TIMEOUT,
+                        description = "Ack timeout in seconds, Supported only with nats streaming broker.",
+                        type = DataType.LONG
+                ),
                 @Parameter(name = NATSConstants.OPTIONAL_CONFIGURATION,
                         description = "This parameter contains all the other possible configurations that the nats" +
                                 " client can be created with. \n `io.nats.client.reconnect.max:1, io.nats.client." +

--- a/component/src/main/java/io/siddhi/extension/io/nats/sink/NATSSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/sink/NATSSink.java
@@ -85,8 +85,9 @@ import java.util.Map;
                                 "streaming broker",
                         type = DataType.STRING
                 ),
-                @Parameter(name = NATSConstants.ACK_TIMEOUT,
-                        description = "Ack timeout in seconds, Supported only with nats streaming broker.",
+                @Parameter(name = NATSConstants.ACK_WAIT,
+                        description = "Ack timeout in seconds for nats publisher, Supported only with nats streaming " +
+                                "broker.",
                         type = DataType.LONG
                 ),
                 @Parameter(name = NATSConstants.OPTIONAL_CONFIGURATION,

--- a/component/src/main/java/io/siddhi/extension/io/nats/sink/nats/NATSCore.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/sink/nats/NATSCore.java
@@ -43,7 +43,6 @@ public class NATSCore {
 
     private static final Logger log = Logger.getLogger(NATSCore.class);
     protected Option destination;
-    protected String clientId;
     protected String[] natsUrls;
     protected String streamId;
     protected String siddhiAppName;

--- a/component/src/main/java/io/siddhi/extension/io/nats/sink/nats/NATSStreaming.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/sink/nats/NATSStreaming.java
@@ -65,8 +65,8 @@ public class NATSStreaming extends NATSCore {
                 siddhiAppName, streamId));
         this.optionsBuilder = new Options.Builder().clientId(clientId).clusterId(this.clusterId).
                 connectionLostHandler(new NATSStreaming.NATSConnectionLostHandler());
-        if (optionHolder.isOptionExists(NATSConstants.ACK_TIMEOUT)) {
-            long ackWait = Long.parseLong(optionHolder.validateAndGetStaticValue(NATSConstants.ACK_TIMEOUT));
+        if (optionHolder.isOptionExists(NATSConstants.ACK_WAIT)) {
+            long ackWait = Long.parseLong(optionHolder.validateAndGetStaticValue(NATSConstants.ACK_WAIT));
             this.optionsBuilder.pubAckWait(Duration.ofSeconds(ackWait));
         }
     }

--- a/component/src/main/java/io/siddhi/extension/io/nats/sink/nats/NATSStreaming.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/sink/nats/NATSStreaming.java
@@ -33,6 +33,7 @@ import io.siddhi.extension.io.nats.util.NATSUtils;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -60,10 +61,14 @@ public class NATSStreaming extends NATSCore {
         } else if (optionHolder.isOptionExists(NATSConstants.STREAMING_CLUSTER_ID)) {
             this.clusterId = optionHolder.validateAndGetStaticValue(NATSConstants.STREAMING_CLUSTER_ID);
         }
-        this.clientId = optionHolder.validateAndGetStaticValue(NATSConstants.CLIENT_ID, NATSUtils.createClientId(
+        String clientId = optionHolder.validateAndGetStaticValue(NATSConstants.CLIENT_ID, NATSUtils.createClientId(
                 siddhiAppName, streamId));
-        this.optionsBuilder = new Options.Builder().clientId(this.clientId).clusterId(this.clusterId).
+        this.optionsBuilder = new Options.Builder().clientId(clientId).clusterId(this.clusterId).
                 connectionLostHandler(new NATSStreaming.NATSConnectionLostHandler());
+        if (optionHolder.isOptionExists(NATSConstants.ACK_TIMEOUT)) {
+            long ackWait = Long.parseLong(optionHolder.validateAndGetStaticValue(NATSConstants.ACK_TIMEOUT));
+            this.optionsBuilder.pubAckWait(Duration.ofSeconds(ackWait));
+        }
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/io/nats/source/NATSSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/source/NATSSource.java
@@ -117,6 +117,13 @@ import java.util.Map;
                         type = DataType.STRING,
                         defaultValue = "-"
                 ),
+                @Parameter(name = NATSConstants.ACK_WAIT,
+                        description = "Add `ack wait` interval for nats subscriptions in seconds. Supported only with" +
+                                " nats streaming brokers.",
+                        optional = true,
+                        type = DataType.LONG,
+                        defaultValue = "-"
+                ),
                 @Parameter(name = NATSConstants.AUTH_TYPE,
                         description = "Set the authentication type. Should be provided when using secure connection." +
                                 " Supported authentication types: `user, token, tls`",

--- a/component/src/main/java/io/siddhi/extension/io/nats/util/NATSConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/util/NATSConstants.java
@@ -45,7 +45,7 @@ public class NATSConstants {
     public static final String STORE_TYPE = "tls.store.type";
     public static final String CLIENT_VERIFY = "client.verify";
     public static final String OPTIONAL_CONFIGURATION = "optional.configuration";
-    public static final String ACK_TIMEOUT = "ack.timeout";
+    public static final String ACK_WAIT = "ack.wait";
 
     public static final String DEFAULT_KEYSTORE_PATH = "${carbon.home}/resources/security/wso2carbon.jks";
     public static final String DEFAULT_TRUSTSTORE_PATH = "${carbon.home}/resources/security/client-truststore.jks";

--- a/component/src/main/java/io/siddhi/extension/io/nats/util/NATSConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/util/NATSConstants.java
@@ -45,6 +45,7 @@ public class NATSConstants {
     public static final String STORE_TYPE = "tls.store.type";
     public static final String CLIENT_VERIFY = "client.verify";
     public static final String OPTIONAL_CONFIGURATION = "optional.configuration";
+    public static final String ACK_TIMEOUT = "ack.timeout";
 
     public static final String DEFAULT_KEYSTORE_PATH = "${carbon.home}/resources/security/wso2carbon.jks";
     public static final String DEFAULT_TRUSTSTORE_PATH = "${carbon.home}/resources/security/client-truststore.jks";


### PR DESCRIPTION
## Purpose
- Fix #34 
- give support for nats-sink to set ack timeout
- convert clientId into a local variable

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
