### PR TITLE
remove CLUSTER_ID default value to allow using NATSCore

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/nats/source/NATSSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/nats/source/NATSSource.java
@@ -76,8 +76,7 @@ import java.util.Map;
                         description = "Deprecated, use `" + NATSConstants.STREAMING_CLUSTER_ID + "` instead. The " +
                                 "identifier of the NATS server/cluster. Should be provided when using nats " +
                                 "streaming broker.",
-                        type = DataType.STRING,
-                        defaultValue = "-"
+                        type = DataType.STRING
                 ),
                 @Parameter(name = NATSConstants.STREAMING_CLUSTER_ID,
                         description = "The identifier of the NATS server/cluster. Should be provided when using nats " +


### PR DESCRIPTION
## Purpose
> Fix the reported bug that makes it impossible to use NatsCORE: Resolves #40

## Goals
> see "Purpose"

## Approach
> Remove the default value for the CLUSTER_ID because if the parameter has got a value the code will always create a NATSStreaming connection.

## User stories
> As a developer I want to be able to use a NatsCORE connection.

## Release note
> If you don't provide a CLUSTER_ID the module will use NatsCORE instead of NatsSTREAMING.